### PR TITLE
chore: replace docker-compose with correct notation

### DIFF
--- a/pull
+++ b/pull
@@ -284,7 +284,7 @@ else
   if [ $environment = 'docker' ];
   then
     docker cp $databaseFilename $dockerDatabaseHost:/var/www/html/$databaseFilename
-    docker-compose exec -T database mysql --user="$dockerDatabaseUser" --password="$dockerDatabasePassword" $dockerDatabaseName < $databaseFilename
+    docker compose exec -T database mysql --user="$dockerDatabaseUser" --password="$dockerDatabasePassword" $dockerDatabaseName < $databaseFilename
   fi
   if [ $environment = 'local' ];
   then


### PR DESCRIPTION
v2 still uses the old `docker-compose` notation which is no longer supported.
This change only replaces it with the new `docker compose`.